### PR TITLE
Convert to a true Rails::Engine

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,6 +15,9 @@ Create initializer, for example config/initializers/translator.rb:
     Translator.current_store = Translator::MongoStore.new(conn)
     I18n.backend = Translator.setup_backend(I18n::Backend::Simple.new)
 
+In Rails > 3.1 you should mount the translator Engine in config/routes.rb:
+    mount Translator::Engine, :to => '/admin' # will provide a /admin/translations path
+
 === For Redis:
 
 Create Gemfile and run "bundle":

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,10 @@
-Rails.application.routes.draw do
-  resources :translations, :to => "Translator::Translations"
+# When Rails >= 3.1
+if defined?(Translator::Engine)
+  Translator::Engine.routes.draw do
+    resources :translations
+  end
+else
+  Rails.application.routes.draw do
+    resources :translations, :to => "Translator::Translations"
+  end
 end

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -1,4 +1,4 @@
-require 'translator/engine' if defined?(Rails) && Rails::VERSION::MAJOR == 3
+require 'translator/engine' if defined?(Rails) && Rails::VERSION::STRING.to_f >= 3.1
 
 module Translator
   class << self

--- a/lib/translator/engine.rb
+++ b/lib/translator/engine.rb
@@ -1,4 +1,5 @@
 module Translator
   class Engine < Rails::Engine
+    isolate_namespace Translator
   end
 end


### PR DESCRIPTION
This change makes it possible to mount the translator to any path.
