### PR TITLE
Fix Proc#bind being depreciated in activesupport 4.2

### DIFF
--- a/app/controllers/translator/translations_controller.rb
+++ b/app/controllers/translator/translations_controller.rb
@@ -78,7 +78,7 @@ module Translator
     private
 
     def auth
-      Translator.auth_handler.bind(self).call if Translator.auth_handler.is_a? Proc
+      self.instance_eval(&Translator.auth_handler) if Translator.auth_handler.is_a? Proc
     end
 
     def paginate(collection)
@@ -89,4 +89,3 @@ module Translator
     end
   end
 end
-

--- a/spec/controllers/translations_controller_spec.rb
+++ b/spec/controllers/translations_controller_spec.rb
@@ -1,0 +1,32 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+RSpec.describe Translator::TranslationsController do
+
+  before :all do
+    conn = Mongo::Connection.new.db("translator_test").collection("translations")
+    Translator.current_store = Translator::MongoStore.new(conn)
+    I18n.backend = Translator.setup_backend(I18n::Backend::Simple.new)
+  end
+
+  after :all do
+    Translator.auth_handler = nil
+  end
+
+  describe "GET index" do
+    context "auth_handler" do
+      it "responds OK with no auth proc" do
+        get :index, use_route: '/'
+        expect(response.status).to eq(200)
+      end
+
+      it "responds 401 with auth proc defined" do
+        Translator.auth_handler = proc {
+          head 401
+        }
+        get :index, use_route: '/'
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently can't use with rails 4.2 and auth_handler defined, as activesupport 4.2.0 depreciated Proc#bind method.

usecase
https://github.com/dziemian007/translator/compare/rails-4.2
```
Failures:

  1) Translator::TranslationsController GET index auth_handler responds 401 with auth proc defined
     Failure/Error: get :index, use_route: '/'
     NoMethodError:
       undefined method `bind' for #<Proc:0x00000004feedf0>
     # ./app/controllers/translator/translations_controller.rb:81:in `auth'
     # ./spec/controllers/translations_controller_spec.rb:27:in `block (4 levels) in <top (required)>'
```